### PR TITLE
Update AbelianPcpGroup, support infinity

### DIFF
--- a/doc/libraries.xml
+++ b/doc/libraries.xml
@@ -7,11 +7,14 @@
 
 There are the following generic pcp-groups available.
 <ManSection>
-<Func Name="AbelianPcpGroup" Arg="n, rels"/>
+<Func Name="AbelianPcpGroup" Arg="n[, rels]"/>
+<Func Name="AbelianPcpGroup" Arg="rels"/>
 <Description>
       constructs the   abelian  group  on  <A>n</A>  generators  such  that
       generator <M>i</M> has  order <M>rels[i]</M>. If  this  order is infinite,
-      then <M>rels[i]</M> should be either unbound or 0.
+      then <M>rels[i]</M> should be either unbound or 0 or infinity.
+      If <A>n</A> is not provided then the length of <A>rels</A> is used.
+      If <A>rels</A> is omitted then all generators will have infinite order.
 </Description>
 </ManSection>
 

--- a/doc/methods.xml
+++ b/doc/methods.xml
@@ -729,7 +729,7 @@ g2^-2*g4
 	and <M>R/C</M> is isomorphic to <A>M</A>.
 
 <Example><![CDATA[
-gap> G := AbelianPcpGroup( 3,[] );
+gap> G := AbelianPcpGroup( 3 );
 Pcp-group with orders [ 0, 0, 0 ]
 gap> ext := SchurCover( G );
 Pcp-group with orders [ 0, 0, 0, 0, 0, 0 ]
@@ -753,7 +753,7 @@ true
 <Example><![CDATA[
 gap> G := DihedralPcpGroup( 0 );
 Pcp-group with orders [ 2, 0 ]
-gap> DirectProduct( G, AbelianPcpGroup( 2, [] ) );
+gap> DirectProduct( G, AbelianPcpGroup( 2 ) );
 Pcp-group with orders [ 0, 0, 2, 0 ]
 gap> AbelianInvariantsMultiplier( last );
 [ 0, 2, 2, 2, 2 ]

--- a/gap/basic/construct.gi
+++ b/gap/basic/construct.gi
@@ -40,7 +40,7 @@ function( filter, ints )
     # construct group
     coll := FromTheLeftCollector( n );
     for i in [1..n] do
-        if IsBound( r[i] ) and r[i] > 0 then
+        if IsBound( r[i] ) and r[i] > 0 and r[i] <> infinity then
             SetRelativeOrder( coll, i, r[i] );
         fi;
     od;


### PR DESCRIPTION
The documentation for AbelianPcpGroup was incomplete and didn't mention
the single argument variants. Also teach AbelianPcpGroup to support
taking the value `infinity` as relative order (as an alternative to using
zero to indicate infinite order).