### PR TITLE
Fix bug in IsNormal, increase rank of our FittingSubgroup method

### DIFF
--- a/gap/basic/pcpgrps.gi
+++ b/gap/basic/pcpgrps.gi
@@ -160,22 +160,6 @@ end );
 
 #############################################################################
 ##
-#M IsNormal( H, U ) . . . . . . . . . . . . . . .test if U is normalized by H
-##
-InstallMethod( IsNormalOp, "for pcp groups",
-               IsIdenticalObj, [ IsPcpGroup, IsPcpGroup ],
-function( H, U )
-    local u, h;
-    for h in GeneratorsOfPcp( Pcp(H, U)) do
-        for u in Igs(U) do
-            if not u^h in U then return false; fi;
-        od;
-    od;
-    return true;
-end );
-
-#############################################################################
-##
 #M Size( <pcpgrp> )
 ##
 InstallMethod( Size, [ IsPcpGroup ],

--- a/gap/pcpgrp/fitting.gi
+++ b/gap/pcpgrp/fitting.gi
@@ -56,6 +56,7 @@ end );
 ##
 InstallMethod( FittingSubgroup,
                "for pcp groups", [IsPcpGroup],
+			   SUM_FLAGS, # Prevent generic GAP library method for finite groups being ranked higher
 function( G )
     local efas, pcps, l, F, i;
 
@@ -253,4 +254,3 @@ InstallGlobalFunction( NilpotentByAbelianByFiniteSeries, function( G )
     if IndexNC( G, A ) = infinity then Error("wrong subgroup"); fi;
     return [G, A, F, U];
 end );
-

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -498,4 +498,19 @@ gap> Random( TrivialGroup( IsPcpGroup ) );
 id
 
 #
+# Fix a bug in IsNormal
+# <https://github.com/gap-packages/polycyclic/issues/46>
+#
+gap> g := PcGroupToPcpGroup(SmallGroup(48,1));
+Pcp-group with orders [ 2, 2, 2, 2, 3 ]
+gap> S := SylowSubgroup( g, 2 );
+Pcp-group with orders [ 2, 2, 2, 2 ]
+gap> T := S^g.5;
+Pcp-group with orders [ 2, 2, 2, 2 ]
+gap> IsNormal( S, T );
+false
+gap> IsNormal( T, S );
+false
+
+#
 gap> STOP_TEST( "bugfix.tst", 10000000);


### PR DESCRIPTION
See https://github.com/gap-packages/polycyclic/issues/46#issuecomment-836857720 for a (lengthy) explanation.

While this PR should fix the issues mentioned in #46, it could probably use some polish and/or extra checks:
 - Perhaps there was a good reason why `IsNormal` had `Pcp(H, U)` in it? Maybe it works correctly if `U` is a subgroup of `H`?
 - I've simply added a large number to the filter rank in `FittingSubgroup`. There's probably a better solution?