### PR TITLE
Allow Centralizer to fall back on generic GAP methods (review needed)

### DIFF
--- a/gap/pcpgrp/centcon.gi
+++ b/gap/pcpgrp/centcon.gi
@@ -165,7 +165,7 @@ CentralizerPcpGroup := function( G, g )
 
     # check
     if ForAny( g, x -> not x in G ) then
-        Error("elements must be contained in group");
+        TryNextMethod();
     fi;
 
     # compute

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -513,4 +513,14 @@ gap> IsNormal( T, S );
 false
 
 #
+# Allow Centralizer to fall back on generic GAP methods
+# <https://github.com/gap-packages/polycyclic/issues/64>
+#
+gap> G := PcGroupToPcpGroup( SmallGroup( 16, 11 ) );;
+gap> g := G.1*G.3*G.4;;
+gap> H := Subgroup( G,[ G.2, G.3, G.4 ] );;
+gap> Centralizer( H, g );
+Pcp-group with orders [ 2, 2 ]
+
+#
 gap> STOP_TEST( "bugfix.tst", 10000000);


### PR DESCRIPTION
See #64. Of course, if there is a reason for forcing this error, this shouldn't be merged.