### PR TITLE
fixed the `AbelianGroupCons` method for `IsPcpGroup`

### DIFF
--- a/gap/basic/construct.gi
+++ b/gap/basic/construct.gi
@@ -24,7 +24,7 @@ InstallMethod( AbelianGroupCons,
     "pcp group",
     [ IsPcpGroup, IsList ],
 function( filter, ints )
-    local coll, i, n, r, grp;
+    local coll, i, n, r, grp, gens, pos;
 
     if not ForAll( ints, x -> IsInt(x) or IsInfinity(x) )  then
         Error( "<ints> must be a list of integers" );
@@ -34,8 +34,8 @@ function( filter, ints )
         TryNextMethod();
     fi;
 
-    n := Length(ints);
-    r := ints;
+    r := Filtered( ints, x -> x <> 1 );
+    n := Length(r);
 
     # construct group
     coll := FromTheLeftCollector( n );
@@ -46,6 +46,19 @@ function( filter, ints )
     od;
     UpdatePolycyclicCollector(coll);
     grp := PcpGroupByCollectorNC( coll );
+    if 1 in ints then
+        gens:= [];
+        pos:= 1;
+        for i in [ 1 .. Length( ints ) ] do
+            if ints[i] = 1 then
+                gens[i]:= One( grp );
+            else
+                gens[i]:= GeneratorsOfGroup( grp )[ pos ];
+                pos:= pos + 1;
+            fi;
+        od;
+        grp:= GroupWithGenerators( gens );
+    fi;
     SetIsAbelian( grp, true );
     return grp;
 end );

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -523,4 +523,17 @@ gap> GroupHomomorphismByImages(G, H, [One(G)], [One(H)]);
 [ id ] -> [ id ]
 
 #
-gap> STOP_TEST( "bugfix.tst", 10000000);
+# Fix a bug in the AbelianGroupCons method for IsPcpGroup.
+# (Generators of order 1 are in principle supported,
+# but we got an error when all generators had order 1,
+# and the group was corrupted when some but not all generators had order 1.)
+#
+gap> AbelianGroup( IsPcpGroup, [ 1 ] );
+Pcp-group with orders [  ]
+gap> g:= AbelianGroup( IsPcpGroup, [ 1, 2 ] );
+Pcp-group with orders [ 2 ]
+gap> List( GeneratorsOfGroup( g ), Order );
+[ 1, 2 ]
+
+#
+gap> STOP_TEST( "bugfix.tst" );


### PR DESCRIPTION
Generators of order 1 are in principle supported,
but we got an error when all generators had order 1, and the group was corrupted when some but not all generators had order 1.

See gap-system/gap/issues/5430 for details.