### PR TITLE
changing to NC versions of Preimages...

### DIFF
--- a/gap/basic/convert.gi
+++ b/gap/basic/convert.gi
@@ -167,7 +167,7 @@ function( G )
     iso  := IsomorphismPcGroup( G );
     F    := Image( iso );
     H    := PcGroupToPcpGroup( F );
-    gens := List( Pcgs(F), x -> PreImagesRepresentative( iso, x ) );
+    gens := List( Pcgs(F), x -> PreImagesRepresentativeNC( iso, x ) );
     hom  := GroupHomomorphismByImagesNC( G, H, gens, AsList(Pcp(H)) );
     SetIsBijective( hom, true );
     return hom;

--- a/gap/basic/grphoms.gi
+++ b/gap/basic/grphoms.gi
@@ -287,7 +287,7 @@ end );
 ##
 #M  PreImages
 ##
-InstallMethod( PreImagesRepresentative,
+InstallMethod( PreImagesRepresentativeNC,
                "for ToPcpGHBI",
                FamRangeEqFamElm,
                [ IsToPcpGHBI, IsPcpElement ],
@@ -299,19 +299,16 @@ function( hom, elm )
     return MappedVector(e, hom!.igs_imgs_to_gens[2]);
 end );
 
-InstallMethod( PreImagesSet,
+InstallMethod( PreImagesSetNC,
                "for PcpGHBI",
                CollFamRangeEqFamElms,
                [ IsFromPcpGHBI and IsToPcpGHBI, IsPcpGroup ],
 function( hom, U )
-    local prei, kern;
-    prei := List( Igs(U), x -> PreImagesRepresentative(hom,x) );
+    local prei, gens, kern;
+    prei := List( Igs(U), x -> PreImagesRepresentativeNC(hom,x) );
     if fail in prei then
-    	TryNextMethod();
-		# Potential solution: Intersect U with ImagesSource(hom)
-		# and then compute the preimage of that.
-		#gens := GeneratorsOfGroup( Intersection( ImagesSource(hom), U ) );
-        #prei := List( gens, x -> PreImagesRepresentative(hom,x) );
+        gens := GeneratorsOfGroup( Intersection( ImagesSource(hom), U ) );
+        prei := List( gens, x -> PreImagesRepresentativeNC(hom,x) );
     fi;
     kern := Igs( KernelOfMultiplicativeGeneralMapping( hom ) );
     return SubgroupByIgs( Source(hom), kern, prei );

--- a/gap/cover/const/aut.gi
+++ b/gap/cover/const/aut.gi
@@ -24,7 +24,7 @@ end );
 BindGlobal( "ReduceAuto", function( auto, C, isom, gens, imgs )
     local news;
     news := List(imgs, x -> Image(auto, x));
-    news := List(news, x -> PreImagesRepresentative(isom, x));
+    news := List(news, x -> PreImagesRepresentativeNC(isom, x));
     news := GroupHomomorphismByImagesNC( C, C, gens, news );
     SetIsBijective( news, true );
     return news;

--- a/gap/exam/generic.gi
+++ b/gap/exam/generic.gi
@@ -183,7 +183,7 @@ InstallGlobalFunction( MaximalOrderByUnitsPcpGroup, function(f)
     G := Image(i);
 
     # get action of U on O
-    u := List( Pcp(G), x -> PreImagesRepresentative(i,x) );
+    u := List( Pcp(G), x -> PreImagesRepresentativeNC(i,x) );
     a := List( u, x -> List( O, y -> Coefficients(O, y*x)));
 
     # return split extension

--- a/gap/pcpgrp/centcon.gi
+++ b/gap/pcpgrp/centcon.gi
@@ -304,7 +304,7 @@ BindGlobal( "ConjugacyElementsBySeries", function( G, g, h, pcps )
             # extract results
             if IsBool(stb) then return false; fi;
             C := PreImage( nat, stb.stab );
-            k := k * PreImagesRepresentative( nat, stb.prei );
+            k := k * PreImagesRepresentativeNC( nat, stb.prei );
         fi;
     od;
 

--- a/gap/pcpgrp/general.gi
+++ b/gap/pcpgrp/general.gi
@@ -144,7 +144,7 @@ function( G )
     F := FrattiniSubgroup(K);
     f := List( GeneratorsOfGroup(F), x ->
          MappedVector( ExponentsOfPcElement(Pcgs(K), x), Igs(H) ) );
-    h := List( f, x -> PreImagesRepresentative(H!.bijection,x));
+    h := List( f, x -> PreImagesRepresentativeNC(H!.bijection,x));
     return Subgroup( G, h );
 end );
 

--- a/gap/pcpgrp/pcpattr.gi
+++ b/gap/pcpgrp/pcpattr.gi
@@ -56,6 +56,6 @@ function( G, p )
     fi;
     # HACK: Until we write a proper native method, use that for pc groups
     iso := IsomorphismPcGroup(G);
-    return PreImagesSet(iso, SylowSubgroup(Image(iso),p));
+    return PreImagesSetNC(iso, SylowSubgroup(Image(iso),p));
 end );
 

--- a/gap/pcpgrp/schur.gi
+++ b/gap/pcpgrp/schur.gi
@@ -192,8 +192,8 @@ BindGlobal( "NonAbelianExteriorSquareEpimorphism", function( G )
     SetIsSurjective( epi, true );
 
     lambda := function( g, h )
-        return Comm( PreImagesRepresentative( lift, g ),
-                     PreImagesRepresentative( lift, h ) );
+        return Comm( PreImagesRepresentativeNC( lift, g ),
+                     PreImagesRepresentativeNC( lift, h ) );
     end;
 
     D!.epimorphism := epi;

--- a/gap/pcpgrp/tensor.gi
+++ b/gap/pcpgrp/tensor.gi
@@ -522,7 +522,7 @@ BindGlobal( "NonAbelianTensorSquareEpimorphism", function( G )
     GoG := Subgroup(U, c);
     gens := GeneratorsOfGroup( GoG );
     embed := Image( epi )!.embedding;
-    imgs := List( gens, g->PreImagesRepresentative( embed, Image( epi, g ) ) );
+    imgs := List( gens, g->PreImagesRepresentativeNC( embed, Image( epi, g ) ) );
 
     alpha := GroupHomomorphismByImagesNC( GoG, Source( embed ), gens, imgs );
     SetIsSurjective( alpha, true );

--- a/init.g
+++ b/init.g
@@ -5,6 +5,17 @@
 #W                                                                   Max Horn
 ##
 
+#############################################################################
+##I introduce the NC versions of PreImages...
+if not IsBound( PreImagesNC ) then
+    BindGlobal( "PreImagesNC", PreImages );
+fi;
+if not IsBound( PreImagesSetNC ) then
+    BindGlobal( "PreImagesSetNC", PreImagesSet );
+fi;
+if not IsBound( PreImagesRepresentativeNC ) then
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative );
+fi;
 
 #############################################################################
 ##

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -353,7 +353,7 @@ gap> iso := IsomorphismPcpGroup(P2);;
 gap> G:=Image(iso);;
 gap> U := Subgroup(G,[G.3*G.5*G.8*G.9*G.10*G.13*G.15*G.17*G.18*G.19,G.15*G.17]);;
 gap> N := NormalizerPcpGroup( G, U );;
-gap> Images(iso, Normalizer( P2, PreImages(iso, U) )) = N;
+gap> Images(iso, Normalizer( P2, PreImagesNC(iso, U) )) = N;
 true
 
 #
@@ -437,9 +437,9 @@ gap> G := AbelianPcpGroup( [ 2 ] );
 Pcp-group with orders [ 2 ]
 gap> phi := GroupHomomorphismByImages( G, G, [ G.1 ], [ Identity( G ) ] );
 [ g1 ] -> [ id ]
-gap> PreImagesRepresentative( phi, One(G) );
+gap> PreImagesRepresentativeNC( phi, One(G) );
 id
-gap> PreImagesRepresentative( phi, G.1 );
+gap> PreImagesRepresentativeNC( phi, G.1 );
 fail
 
 #
@@ -447,11 +447,11 @@ gap> G := AbelianPcpGroup( [ 2, 2 ] );
 Pcp-group with orders [ 2, 2 ]
 gap> phi := GroupHomomorphismByImages( G, G, [ G.1, G.2 ], [ Identity( G ), G.2 ] );
 [ g1, g2 ] -> [ id, g2 ]
-gap> PreImagesRepresentative( phi, One(G) );
+gap> PreImagesRepresentativeNC( phi, One(G) );
 id
-gap> PreImagesRepresentative( phi, G.2 );
+gap> PreImagesRepresentativeNC( phi, G.2 );
 g2
-gap> PreImagesRepresentative( phi, G.1 );
+gap> PreImagesRepresentativeNC( phi, G.1 );
 fail
 
 #

--- a/tst/homs.tst
+++ b/tst/homs.tst
@@ -307,12 +307,12 @@ true
 #
 gap> G:=AbelianGroup(IsPcpGroup,[2,3,2]);;
 gap> map:=GroupGeneralMappingByImages(G,G,[G.1],[G.3]);;
-gap> Size(PreImagesSet(map,G));
+gap> Size(PreImagesSetNC(map,G));
 2
 gap> List([IsTotal,IsSingleValued,IsSurjective,IsInjective], f->f(map));
 [ false, true, false, true ]
 gap> map2:=map*map;;
-gap> Size(PreImagesSet(map2,G));
+gap> Size(PreImagesSetNC(map2,G));
 1
 gap> Size(ImagesSet(map2,G));
 1

--- a/tst/inters.tst
+++ b/tst/inters.tst
@@ -95,9 +95,9 @@ gap> H2 := Subgroup(H,[h[1]*h[7], h[4]*h[5]]);
 Pcp-group with orders [ 3, 3, 3, 3 ]
 gap> J := Intersection(H1,H2);
 Error, sorry: intersection for non-normal groups not yet installed
-gap> G1 := PreImages(iso,H1);
+gap> G1 := PreImagesNC(iso,H1);
 Group([ f2, f3*f4, f6 ])
-gap> G2 := PreImages(iso,H2);
+gap> G2 := PreImagesNC(iso,H2);
 Group([ f1*f7, f4*f5 ])
 gap> I:= Intersection(G1,G2);
 Group([ f3^2*f4*f5^2, f4^2*f5, f5^2 ])
@@ -115,9 +115,9 @@ gap> H2 := Subgroup(H,[h[1]*h[7], h[4]*h[5]^2]);
 Pcp-group with orders [ 2, 3, 3, 3 ]
 gap> Intersection(H1,H2);
 Error, sorry: intersection for non-normal groups not yet installed
-gap> G1 := PreImages(iso,H1);
+gap> G1 := PreImagesNC(iso,H1);
 Group([ f2, f3*f4, f6^2 ])
-gap> G2 := PreImages(iso,H2);
+gap> G2 := PreImagesNC(iso,H2);
 Group([ f1*f7, f4*f5^2 ])
 gap> I:= Intersection(G1,G2);
 Group([ f6^2, f7^2 ])


### PR DESCRIPTION
PreImages, PreImagesElm, PreImagesSet and PreImagesRepresetnative, can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809.
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions.
The procedure to be adopted is as follows.
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these. PR #5073 addresses this.
(2) Ask package authors/maintainers to convert all their calls to these functions to the NC versions (unless there is good reason not to do so).
A clause added to init.g ensures that the package still works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations.

This PR attempts to implement (2) for package polycyclic.  Why was this PR not made earlier when most of the other packages have made changes?  Probably because of a comment by @fingolfin in PR#5073 that a major bug had to be fixed. 
This PR defines 3 NC versions in init.g (PreImagesElm is not used) and changes calls to NC versions in 10 library files. A second commit makes a similar adjustment to some of the tests - perhaps these should not have been changed? 
Changes made in the unmerged polycyclic PR#48 to the method for PreImagesSet have been included here (was that wise?).