### PR TITLE
Ensure SchurCovers returns a list if only one cover is found

### DIFF
--- a/gap/cover/const/cov.gi
+++ b/gap/cover/const/cov.gi
@@ -27,7 +27,7 @@ BindGlobal( "SchurCovers", function(G)
     Print("  Schur Mult has type ",AbelianInvariants(M),"\n");
 
     # catch a trival case
-    if GG!.mord = 1 then return G; fi;
+    if GG!.mord = 1 then return [ G ]; fi;
 
     # determine Z = Z(K) cap RK'
     D := ProductPcpGroups(K, R, DerivedSubgroup(K));

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -566,4 +566,12 @@ gap> Size(F);  # used to produce a group of order 49
 21
 
 #
+# Fix a bug in SchurCovers
+# <https://github.com/gap-packages/polycyclic/issues/93>
+#
+gap> SchurCovers( CyclicGroup( 4 ) );
+  Schur Mult has type [  ]
+[ <pc group of size 4 with 2 generators> ]
+
+#
 gap> STOP_TEST( "bugfix.tst" );


### PR DESCRIPTION
This resolves the bug in #93, but does not address the request to disable debug messages.