### PR TITLE
Install a method for SemidirectProduct for PcpGroups

### DIFF
--- a/tst/semidirect.tst
+++ b/tst/semidirect.tst
@@ -1,0 +1,23 @@
+gap> START_TEST("Test of semidirect products");
+
+#
+gap> N := DihedralPcpGroup( 0 );;
+gap> A := Group([
+>    InnerAutomorphism( N, N.1 ),
+>    InnerAutomorphism( N, N.2 ),
+>    GroupHomomorphismByImagesNC( N, N, [ N.1, N.2 ], [ N.1*N.2, N.2^-1 ] )
+> ]);;
+gap> G := AbelianPcpGroup( [ 0 ] );;
+gap> alpha := GroupHomomorphismByImagesNC( G, A, [ G.1 ], [ A.1*A.3 ] );;
+gap> S := SemidirectProduct( G, alpha, N );
+Pcp-group with orders [ 0, 2, 0 ]
+gap> e1 := Embedding( S, 1 );;
+gap> e2 := Embedding( S, 2 );;
+gap> p := Projection( S );;
+gap> e1 * p = IdentityMapping( G );
+true
+gap> ClosureGroup( Image( e1, G ), Image( e2, N ) ) = S;
+true
+
+#
+gap> STOP_TEST( "semidirect.tst", 10000000);


### PR DESCRIPTION
This PR takes installs a method for `SemidirectProduct( N, alpha, G)` where `N` and `G` are both PcpGroups, by delegating the actual construction to the existing (but undocumented?) `SplitExtensionByAutomorphisms` and setting a (mostly empty) `SemidirectProductInfo` attribute. It also installs methods for `Embedding` and `Projection` for a semidirect product constructed this way.

It does not install a method for `SemidirectProduct( N, autgp )`, since `autgp` need not be polycyclic, and even if it is, I don't know whether we can verify that and produce an isomorphism from `autgp` to a PcpGroup.