### PR TITLE
Replace obsolete MutableCopyMat by MutableCopyMatrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,8 +28,6 @@ jobs:
           - stable-4.14
           - stable-4.13
           - stable-4.12
-          - stable-4.11
-          - stable-4.10
 
     steps:
       - uses: actions/checkout@v5

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -123,7 +123,7 @@ PackageDoc     := rec(
 ),
 
 Dependencies    := rec(
-  GAP                    := ">= 4.10",
+  GAP                    := ">= 4.12",
   NeededOtherPackages    := [["alnuth", "3.0"],
                              ["autpgrp","1.6"]],
   SuggestedOtherPackages := [ ],

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ basis for working with polycyclic groups defined by polycyclic
 presentations.
 
 To have the full functionality of the package available you need at
-least GAP version 4.5 and the GAP 4 package Alnuth and its dependencies
+least GAP version 4.12 and the GAP 4 package Alnuth and its dependencies
 must be installed.
 
 The features of this package include

--- a/gap/cohom/onecohom.gi
+++ b/gap/cohom/onecohom.gi
@@ -88,7 +88,7 @@ BindGlobal( "InverseCohMapping", function( coh, base )
 
     # extend base to full lattice
     dep := List( base, PositionNonZero );
-    new := MutableCopyMat( base );
+    new := MutableCopyMatrix( base );
     for i in [1..l] do
         if not i in dep then Add( new, mat[i] ); fi;
     od;

--- a/gap/cohom/solabel.gi
+++ b/gap/cohom/solabel.gi
@@ -234,7 +234,7 @@ BindGlobal( "SolveSystemGauss", function( A, e, p, b )
     # solve mod p
     AA := A*One(F); ConvertToMatrixRepNC(AA, F);
     SE := SemiEchelonMatTransformation(AA);
-    SS := MutableCopyMat(SE.relations); TriangulizeMat(SS);
+    SS := MutableCopyMatrix(SE.relations); TriangulizeMat(SS);
     if f then sl := FindSpecialSolution(SE, b*One(F)); fi;
 
     # extract info
@@ -267,7 +267,7 @@ BindGlobal( "SolveSystemGauss", function( A, e, p, b )
         # apply gauss
         W := J*One(F); ConvertToMatrixRepNC(W, F);
         M := SemiEchelonMatTransformation(W);
-        S := MutableCopyMat(M.relations); TriangulizeMat(S);
+        S := MutableCopyMatrix(M.relations); TriangulizeMat(S);
 
         # consider special solution
         if f then

--- a/gap/cohom/solcohom.gi
+++ b/gap/cohom/solcohom.gi
@@ -138,7 +138,7 @@ end );
 
 BindGlobal( "PermuteMat", function( M, rho, sig )
     local N, i, j;
-    N := MutableCopyMat(M);
+    N := MutableCopyMatrix(M);
     for i in [1..Length(M)] do
         for j in [1..Length(M[1])] do
             N[i][j] := M[i^sig][j^rho];


### PR DESCRIPTION
This also bumps up the minimal required version of GAP from 4.10 to 4.12.