### PR TITLE
Remove test dependencies on PrimGrp/SmallGrp/TransGrp

### DIFF
--- a/tst/AddToIgs.tst
+++ b/tst/AddToIgs.tst
@@ -123,7 +123,7 @@ gap> Igs(gen);
 # Fix a bug in AddToIgs
 # See https://github.com/gap-packages/polycyclic/issues/66
 #
-gap> G := PcGroupToPcpGroup( SmallGroup( 36, 9 ) );;
+gap> G := PcGroupToPcpGroup( PcGroupCode( 14981017363, 36 ) );;
 gap> gensG := [ G.1, G.4 ];;
 gap> G = Subgroup( G, gensG );
 true
@@ -141,7 +141,7 @@ g3^3
 #
 # third example for issue #66
 #
-gap> H := SmallGroup( 36, 9 );;
+gap> H := PcGroupCode( 14981017363, 36 );;
 gap> gensH := [ H.1, H.4 ];;
 gap> H = Subgroup( H, gensH );
 true

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -32,7 +32,7 @@ true
 
 #
 gap> # Check for a bug reported 2012-01-19 by Robert Morse
-gap> g := PcGroupToPcpGroup(SmallGroup(48,1));
+gap> g := PcGroupToPcpGroup(PcGroupCode(61763227873,48));
 Pcp-group with orders [ 2, 2, 2, 2, 3 ]
 gap> # The next two commands used to trigger errors
 gap> NonAbelianTensorSquare(Centre(g));
@@ -156,7 +156,7 @@ gap> cc.gcc;
 #
 gap> # LowerCentralSeriesOfGroup for non-nilpotent pcp-groups used to trigger
 gap> # an infinite recursion
-gap> G := PcGroupToPcpGroup(SmallGroup(6,1));
+gap> G := PcGroupToPcpGroup(PcGroupCode(25,6));
 Pcp-group with orders [ 2, 3 ]
 gap> LowerCentralSeriesOfGroup(G);
 [ Pcp-group with orders [ 2, 3 ], Pcp-group with orders [ 3 ] ]
@@ -392,7 +392,7 @@ Pcp-group with orders [ 4, 3 ]
 # being in the IsAbelian (and even the IsCyclic) filter.
 # <https://github.com/gap-packages/polycyclic/issues/28>
 #
-gap> G:=PcGroupToPcpGroup(SmallGroup(5^6,500));
+gap> G:=PcGroupToPcpGroup(PcGroupCode(976875100002560016404991074,5^6));
 Pcp-group with orders [ 5, 5, 5, 5, 5, 5 ]
 gap> N:=NormalClosure(Group(G.2), Group(G.3));
 Pcp-group with orders [ 5, 5, 5, 5 ]
@@ -509,7 +509,7 @@ true
 # Fix a bug in IsNormal
 # <https://github.com/gap-packages/polycyclic/issues/46>
 #
-gap> g := PcGroupToPcpGroup(SmallGroup(48,1));
+gap> g := PcGroupToPcpGroup(PcGroupCode(61763227873,48));
 Pcp-group with orders [ 2, 2, 2, 2, 3 ]
 gap> S := SylowSubgroup( g, 2 );
 Pcp-group with orders [ 2, 2, 2, 2 ]
@@ -581,7 +581,7 @@ id
 # Allow Centralizer to fall back on generic GAP methods
 # <https://github.com/gap-packages/polycyclic/issues/64>
 #
-gap> G := PcGroupToPcpGroup( SmallGroup( 16, 11 ) );;
+gap> G := PcGroupToPcpGroup( PcGroupCode( 520, 16 ) );;
 gap> g := G.1*G.3*G.4;;
 gap> H := Subgroup( G,[ G.2, G.3, G.4 ] );;
 gap> Centralizer( H, g );
@@ -591,7 +591,7 @@ Pcp-group with orders [ 2, 2 ]
 # Fix a bug in CentralizerBySeries
 # <https://github.com/gap-packages/polycyclic/issues/65>
 #
-gap> G := PcGroupToPcpGroup( SmallGroup( 16, 11 ) );;
+gap> G := PcGroupToPcpGroup( PcGroupCode( 520, 16 ) );;
 gap> g := G.2*G.3*G.4;;
 gap> cc := ConjugacyClass( G, g );;
 gap> C := Centralizer( cc );
@@ -642,7 +642,7 @@ Pcp-group with orders [ 2, 0 ]
 # Fix bug in FrattiniSubgroup
 # Reported by Heiko Dietrich (2024-02-19)
 #
-gap> G:=PcGroupToPcpGroup(SmallGroup(11025,6));;
+gap> G:=PcGroupToPcpGroup(PcGroupCode(65691468891906554870039,11025));;
 gap> F:=FrattiniSubgroup(G);;
 gap> Size(F);  # used to produce a group of order 49
 21
@@ -651,7 +651,7 @@ gap> Size(F);  # used to produce a group of order 49
 # Fixed a bug in IsConjugate for a finite pcp-group
 # <https://github.com/gap-packages/polycyclic/issues/70>
 #
-gap> G := PcGroupToPcpGroup( SmallGroup( 1600, 10260 ) );;
+gap> G := PcGroupToPcpGroup( PcGroupCode( 6972476423700447941356396189131961283384217049529126656, 1600 ) );;
 gap> G := Subgroup( G, [ G.1, G.2, G.3, G.4 ] );;
 gap> g := G.2*G.4;; h := g^(G.1*G.3);;
 gap> IsConjugate( G, g, h );

--- a/tst/exam/generic.tst
+++ b/tst/exam/generic.tst
@@ -25,17 +25,47 @@ true
 gap> hom:=GroupHomomorphismByImages( G, Group(G!.mats), Igs(G), G!.mats);;
 
 #
-gap> IdGroup(BlowUpPcpPGroup(SmallGroup(2,1)));
-[ 2, 1 ]
-gap> IdGroup(BlowUpPcpPGroup(SmallGroup(4,1)));
-[ 8, 2 ]
-gap> IdGroup(BlowUpPcpPGroup(SmallGroup(4,2)));
-[ 8, 5 ]
-gap> List([1..5], i->IdGroup(BlowUpPcpPGroup(SmallGroup(8,i))));
-[ [ 128, 1601 ], [ 128, 2319 ], [ 128, 2320 ], [ 128, 2321 ], [ 128, 2328 ] ]
-gap> IdGroup(BlowUpPcpPGroup(SmallGroup(3,1)));
-[ 9, 2 ]
-gap> BlowUpPcpPGroup(SmallGroup(9,1));
+gap> G:=BlowUpPcpPGroup(PcGroupCode(0,2));;
+gap> Size(G);
+2
+gap> G:=BlowUpPcpPGroup(PcGroupCode(5,4));;
+gap> IsAbelian(G);
+true
+gap> AbelianInvariants(G);
+[ 2, 4 ]
+gap> G:=BlowUpPcpPGroup(PcGroupCode(0,4));;
+gap> IsAbelian(G);
+true
+gap> AbelianInvariants(G);
+[ 2, 2, 2 ]
+gap> G:=BlowUpPcpPGroup(PcGroupCode(323,8));;
+gap> IsAbelian(G);
+true
+gap> AbelianInvariants(G);
+[ 2, 2, 4, 8 ]
+gap> G:=BlowUpPcpPGroup(PcGroupCode(33,8));;
+gap> IsAbelian(G);
+true
+gap> AbelianInvariants(G);
+[ 2, 2, 2, 2, 2, 4 ]
+gap> G:=BlowUpPcpPGroup(PcGroupCode(36,8));;
+gap> fac:=DirectFactorsOfGroup(G);;
+gap> Number(fac,F->Size(F)=2);
+4
+gap> Number(fac,F->IsDihedralGroup(F) and Size(F)=8);
+1
+gap> G:=BlowUpPcpPGroup(PcGroupCode(2343,8));;
+gap> fac:=DirectFactorsOfGroup(G);;
+gap> Number(fac,F->Size(F)=2);
+4
+gap> Number(fac,F->IsQuaternionGroup(F) and Size(F)=8);
+1
+gap> G:=BlowUpPcpPGroup(PcGroupCode(0,3));;
+gap> IsAbelian(G);
+true
+gap> AbelianInvariants(G);
+[ 3, 3 ]
+gap> BlowUpPcpPGroup(PcGroupCode(5,9));
 Pcp-group with orders [ 3, 3, 3, 3, 3, 3, 3, 3 ]
-gap> BlowUpPcpPGroup(SmallGroup(9,2));
+gap> BlowUpPcpPGroup(PcGroupCode(0,9));
 Pcp-group with orders [ 3, 3, 3, 3, 3, 3, 3, 3 ]

--- a/tst/inters.tst
+++ b/tst/inters.tst
@@ -1,7 +1,7 @@
 gap> START_TEST("Test for the intersection algorithm");
 
 #some trivial tests
-gap> G := SmallGroup(48,3);;
+gap> G := PcGroupCode(276070751805136,48);;
 gap> iso := IsomorphismPcpGroup(G);;
 gap> H := Image(iso, G);;
 gap> T := TrivialSubgroup(H);;
@@ -56,7 +56,7 @@ gap> List(efa, gp->Pcp(Intersection(F,gp)));
   Pcp [  ] with orders [  ] ]
 
 # a working test with a finite group (pc converted to pcp)
-gap> G := SmallGroup(3^2*5^2*7,7);;
+gap> G := PcGroupCode(508835717541181643,3^2*5^2*7);;
 gap> iso := IsomorphismPcpGroup(G);;
 gap> g := GeneratorsOfGroup(G);;
 gap> G1 := Subgroup(G, [g[2]*g[1]^2, g[3]*g[4]]);
@@ -85,7 +85,7 @@ gap> Intersection(H1,H2);
 Error, sorry: intersection for non-normal groups not yet installed
 
 # finite group example where the intersection isn't impl. when represented as a pcp-group (non-normalizing case)
-gap> G := SmallGroup(2^2*3^4*5,8);;
+gap> G := PcGroupCode(45446527802282484537974096,2^2*3^4*5);;
 gap> iso := IsomorphismPcpGroup(G);;
 gap> H := Image(iso);;
 gap> h := GeneratorsOfGroup(H);;
@@ -105,7 +105,7 @@ gap> Image(iso,I);
 Pcp-group with orders [ 3, 3, 3 ]
 
 # finite group example where the intersection isn't impl. when represented as a pcp-group (non-normalizing case)
-gap> G := SmallGroup(2^2*3^5,250);;
+gap> G := PcGroupCode(15825634281851454495,2^2*3^5);;
 gap> iso := IsomorphismPcpGroup(G);;
 gap> H := Image(iso);;
 gap> h := GeneratorsOfGroup(H);;

--- a/tst/isom.tst
+++ b/tst/isom.tst
@@ -75,17 +75,18 @@ false
 # Test with dihedral group
 #
 gap> K:=DihedralGroup(IsPcpGroup, 16);;
-gap> IdSmallGroup(K);
-[ 16, 7 ]
 gap> iso:=IsomorphismPermGroup(K);;
-gap> IdSmallGroup(Image(iso));
-[ 16, 7 ]
+gap> img:=Image(iso);;
+gap> Size(img)=16 and IsDihedralGroup(img);
+true
 gap> iso:=IsomorphismPcGroup(K);;
-gap> IdSmallGroup(Image(iso));
-[ 16, 7 ]
+gap> img:=Image(iso);;
+gap> Size(img)=16 and IsDihedralGroup(img);
+true
 gap> iso:=IsomorphismFpGroup(K);;
-gap> IdSmallGroup(Image(iso));
-[ 16, 7 ]
+gap> img:=Image(iso);;
+gap> Size(img)=16 and IsDihedralGroup(img);
+true
 
 #
 gap> STOP_TEST( "homs.tst", 10000000);


### PR DESCRIPTION
An attempt to comply with https://github.com/gap-system/gap/issues/2434.

The easy fix would be to add `LoadPackage("smallgrp")` to `tst/testall.g`. But the few times that we use `IdGroup`, it can be replaced in a way that is not overly complicated and keeps the quality of the test intact.