### PR TITLE
Mention AutPGrp in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ basis for working with polycyclic groups defined by polycyclic
 presentations.
 
 To have the full functionality of the package available you need at
-least GAP version 4.12 and the GAP 4 package Alnuth and its dependencies
-must be installed.
+least GAP version 4.12 and the GAP 4 packages Alnuth and AutPGrp and 
+their dependencies must be installed.
 
 The features of this package include
 
@@ -77,8 +77,8 @@ directories:
 Installation
 ------------
 
-Make sure that the GAP 4 package Alnuth is installed to  have the full
-range of methods available in polycyclic.
+Make sure that the GAP 4 packages Alnuth and AutPGrp are installed to 
+have the full range of methods available in polycyclic.
 
 There are two ways of installing the package.  If you have permission
 to add files to the installation directory of GAP 4 on your system,


### PR DESCRIPTION
AutPGrp has been a dependency since version 2.5 (2008-11-25), but currently the README only mentions Alnuth.

Perhaps the wording should also be updated, though? To me, it sounds like Alnuth and AutPGrp are optional and recommended, not needed.