### PR TITLE
Let `Centralizer( U, g )` work if `g` is not contained in `U`

### DIFF
--- a/gap/pcpgrp/centcon.gi
+++ b/gap/pcpgrp/centcon.gi
@@ -155,6 +155,7 @@ end );
 #F Centralizer
 ##
 BindGlobal( "CentralizerPcpGroup", function( G, g )
+    local H, contained, C;
 
     # get arguments
     if IsPcpGroup(g) then
@@ -165,11 +166,21 @@ BindGlobal( "CentralizerPcpGroup", function( G, g )
 
     # check
     if ForAny( g, x -> not x in G ) then
-        TryNextMethod();
+        contained := false;
+        H := ClosureGroup( G, g );
+    else
+        contained := true;
+        H := G;
     fi;
 
     # compute
-    return CentralizerBySeries( G, g, PcpsOfEfaSeries(G) );
+    C := CentralizerBySeries( H, g, PcpsOfEfaSeries(H) );
+
+    if not contained then
+        return Intersection( G, C );
+    else
+        return C;
+    fi;
 end );
 
 InstallMethod( CentralizerOp, "for a pcp group", IsCollsElms,

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -578,16 +578,6 @@ gap> Random( TrivialGroup( IsPcpGroup ) );
 id
 
 #
-# Allow Centralizer to fall back on generic GAP methods
-# <https://github.com/gap-packages/polycyclic/issues/64>
-#
-gap> G := PcGroupToPcpGroup( PcGroupCode( 520, 16 ) );;
-gap> g := G.1*G.3*G.4;;
-gap> H := Subgroup( G,[ G.2, G.3, G.4 ] );;
-gap> Centralizer( H, g );
-Pcp-group with orders [ 2, 2 ]
-
-#
 # Fix a bug in CentralizerBySeries
 # <https://github.com/gap-packages/polycyclic/issues/65>
 #

--- a/tst/cent.tst
+++ b/tst/cent.tst
@@ -1,19 +1,58 @@
 gap> START_TEST("Test for the centralizer algorithm");
 
 #
-gap> G := ExamplesOfSomePcpGroups( 5 );;
-gap> H := Subgroup( G, [ G.1 ] );;
-gap> C := Centralizer( H, G.2 );
-Pcp-group with orders [ 0 ]
-gap> C = Subgroup( G, [ G.4 ] );
+# Centralizers of an infinite group G and an element g,
+# and of a subgroup H (not containing g) and the element g 
+#
+gap> G := ExamplesOfSomePcpGroups( 5 );
+Pcp-group with orders [ 2, 0, 0, 0 ]
+gap> g := G.2;;
+gap> H := Subgroup( G, [ G.1 ] );
+Pcp-group with orders [ 2, 0 ]
+gap> g in H;
+false
+gap> Centralizer( G, g ) = Subgroup( G, [ G.2, G.4 ] );
+true
+gap> Centralizer( H, g ) = Subgroup( G, [ G.4 ] );
 true
 
 #
-gap> G := PcGroupToPcpGroup( PcGroupCode( 520, 16 ) );;
-gap> g := G.1*G.3*G.4;;
-gap> H := Subgroup( G,[ G.2, G.3, G.4 ] );;
-gap> Centralizer( H, g );
-Pcp-group with orders [ 2, 2 ]
+# Centralizers of a finite group G and an element g,
+# and of a subgroup H (not containing g) and the element g 
+#
+gap> G := PcGroupToPcpGroup( PcGroupCode( 520, 16 ) );
+Pcp-group with orders [ 2, 2, 2, 2 ]
+gap> g := G.1 * G.3 * G.4;;
+gap> H := Subgroup( G,[ G.2, G.3, G.4 ] );
+Pcp-group with orders [ 2, 2, 2 ]
+gap> g in H;
+false
+gap> Centralizer( G, g ) = Subgroup( G, [ G.1, G.3, G.4 ] );
+true
+gap> Centralizer( H, g ) = Subgroup( G, [ G.3, G.4 ] );
+true
+
+#
+# Centralizers of two subgroups with the parent group and with
+# each other, where the subgroups do not contain each other
+#
+gap> G := ExamplesOfSomePcpGroups( 1 );
+Pcp-group with orders [ 0, 0, 0, 0 ]
+gap> H := Subgroup( G, [ G.1 ^ 2, G.3 ] );
+Pcp-group with orders [ 0, 0, 0 ]
+gap> K := Subgroup( G, [ G.2 ^ 4, G.4 ] );
+Pcp-group with orders [ 0, 0 ]
+gap> Intersection( H, K );
+Pcp-group with orders [ 0 ]
+gap> 
+gap> Centralizer( G, H ) = Subgroup( G, [ G.2 ^ 2 ] );
+true
+gap> Centralizer( G, K ) = Subgroup( G, [ G.2 ^ 2, G.3, G.4 ] );
+true
+gap> Centralizer( K, H ) = Subgroup( G, [ G.2 ^ 4 ] );
+true
+gap> Centralizer( H, K ) = Subgroup( G, [ G.3, G.4 ] );
+true
 
 #
 gap> STOP_TEST( "cent.tst", 10000000);

--- a/tst/cent.tst
+++ b/tst/cent.tst
@@ -1,0 +1,19 @@
+gap> START_TEST("Test for the centralizer algorithm");
+
+#
+gap> G := ExamplesOfSomePcpGroups( 5 );;
+gap> H := Subgroup( G, [ G.1 ] );;
+gap> C := Centralizer( H, G.2 );
+Pcp-group with orders [ 0 ]
+gap> C = Subgroup( G, [ G.4 ] );
+true
+
+#
+gap> G := PcGroupToPcpGroup( PcGroupCode( 520, 16 ) );;
+gap> g := G.1*G.3*G.4;;
+gap> H := Subgroup( G,[ G.2, G.3, G.4 ] );;
+gap> Centralizer( H, g );
+Pcp-group with orders [ 2, 2 ]
+
+#
+gap> STOP_TEST( "cent.tst", 10000000);


### PR DESCRIPTION
This supersedes https://github.com/gap-packages/polycyclic/pull/68, and is related to the discussion in #111.

The functionality is still limited because `Intersection` does not work in all cases, but it's still an improvement. This should also avoid relying on generic GAP methods that run forever for infinite groups.