### PR TITLE
Fix a bug in `ComplementClassesCR`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ NEXT (YYYY-MM-DD)
   - Fix bugs, where wrong results could be returned or errors could be thrown,
     in the following functions:
     - `ConjugacyElementsBySeries`
+    - `ComplementClassesCR`
   - Various janitorial changes
 
 2.18 (2026-04-09)

--- a/gap/basic/pcppcps.gi
+++ b/gap/basic/pcppcps.gi
@@ -281,7 +281,7 @@ end );
 ## denominator of this pcp.
 ##
 BindGlobal( "AddIgsToIgs", function( pcs1, pcs2 )
-    local coll, rels, n, ind, todo, g, c, h, eg, eh, e, d;
+    local coll, rels, n, ind, todo, g, c, h, eg, eh, e, d, t;
 
     if Length( pcs1 ) = 0 then
         return AsList( pcs2 );
@@ -340,7 +340,13 @@ BindGlobal( "AddIgsToIgs", function( pcs1, pcs2 )
             d := Depth( g );
         od;
     od;
-    return Filtered( ind, x -> not IsBool( x ) );
+    ind := Filtered( ind, x -> not IsBool( x ) );
+    if CHECK_IGS@ then
+        Info(InfoPcpGrp, 1, "checking igs ");
+        t := CheckIgs(ind, Concatenation(AsList(pcs1),AsList(pcs2)));
+        if t <> true then Error("igs is incorrect at ",t); fi;
+    fi;
+    return ind;
 end );
 
 #############################################################################

--- a/gap/cohom/grpcom.gi
+++ b/gap/cohom/grpcom.gi
@@ -213,9 +213,9 @@ InstallGlobalFunction( ComplementClassesCR, function( C )
                 c := CocycleConjugateComplement( C, cc, e.repr, w, g );
                 c := cc.CocToCBElement(cc, c) * cc.trf;
                 g := g * MappedVector( IntVector( c ), C.normal );
-                gens := AddIgsToIgs( [g], gens );
+                gens := AddToIgs( gens, [g] );
             elif g <> g^0 then
-                gens := AddIgsToIgs( [g], gens );
+                gens := AddToIgs( gens, [g] );
             fi;
         od;
 

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -704,4 +704,14 @@ gap> g^k = h;
 true
 
 #
+# Fix a bug in ComplementClassesCR
+# <https://github.com/gap-packages/polycyclic/issues/3>
+#
+gap> tmp := CHECK_IGS@Polycyclic;;
+gap> CHECK_IGS@Polycyclic := true;;
+gap> G:=PcGroupToPcpGroup(PcGroupCode(37830811398924985638637008775811, 144));;
+gap> FiniteSubgroupClasses(G);;
+gap> CHECK_IGS@Polycyclic := tmp;;
+
+#
 gap> STOP_TEST( "bugfix.tst" );


### PR DESCRIPTION
Resolves #125.

Also adds a check on the igs calculated by `AddIgsToIgs`, which only runs if `CHECK_IGS@` is true. 