### PR TITLE
Experimental IGS fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ NEXT (YYYY-MM-DD)
   - Fix bugs, where wrong results could be returned or errors could be thrown,
     in the following functions:
     - `ConjugacyElementsBySeries`
+    - `NormalizerPcpGroup`
+    - `ComplementClassesCR`
   - Various janitorial changes
 
 2.18 (2026-04-09)

--- a/gap/basic/orbstab.gi
+++ b/gap/basic/orbstab.gi
@@ -203,7 +203,7 @@ BindGlobal( "RandomPcpOrbitStabilizer", function( e, pcp, act, op )
                 Add( T, t * gens[j] );
 
                 if Length(O) > 500 then
-                    Print( "#I  Orbit longer than limit: exiting.\n" );
+                    Info( InfoIntStab, 1, "orbit longer than limit: exiting.");
                     return rec( orbit := O, stab := S );
                 fi;
             else
@@ -217,7 +217,7 @@ BindGlobal( "RandomPcpOrbitStabilizer", function( e, pcp, act, op )
                         count := 0;
                     fi;
                     if count > 100 then
-                        Print( "#I  Stabilizer not increasing: exiting.\n" );
+                        Info( InfoIntStab, 1, "stabilizer not increasing: exiting.");
                         return rec( orbit := O, stab := S );
                     fi;
                 fi;
@@ -226,7 +226,7 @@ BindGlobal( "RandomPcpOrbitStabilizer", function( e, pcp, act, op )
 
         i := i+1;
     od;
-    Print( "#I  Orbit calculation complete.\n" );
+    Info( InfoIntStab, 1, "orbit calculation complete.");
     return rec( orbit := O, stab := S );
 end );
 
@@ -245,7 +245,7 @@ BindGlobal( "RandomCentralizerPcpGroup", function( G, g )
             stab := RandomPcpOrbitStabilizer( h, stab, stab, OnPoints ).stab;
         od;
     else
-        Print("g must be a subgroup or an element of G \n");
+        Error("g must be a subgroup or an element of G \n");
     fi;
     return Subgroup( G, stab );
 end );

--- a/gap/basic/pcppara.gi
+++ b/gap/basic/pcppara.gi
@@ -34,6 +34,52 @@ BindGlobal( "NormedPcpElementPara", function( g, gg )
     return [ h, hh ];
 end );
 
+####################################################################
+##
+#F GcdPcpPara
+##
+BindGlobal( "GcdPcpPara", function(g, h, i, j)
+    local x, y, a, b, q, r, t, z, w, u;
+
+    x := g;
+    y := h;
+
+    a := LeadingExponent(x);
+    b := LeadingExponent(y);
+
+    z := i;
+    w := j;
+    
+    if a < 0 then
+        x := x^-1;
+        z := z^-1;
+        a := LeadingExponent(x);
+    fi;
+    if b < 0 then
+        y := y^-1;
+        w := w^-1;
+        b := LeadingExponent(y);
+    fi;
+
+    while b <> 0 do
+        q := QuoInt(a, b);
+        r := a - q * b;
+
+        t := x * y ^ -q;
+        x := y;
+        y := t;
+
+        u := z * w ^ -q;
+        z := w;
+        w := u;
+
+        a := b;
+        b := r;
+    od;
+
+    return [x, y, z, w];
+end );
+
 #############################################################################
 ##
 #F ReduceExpoPara( ind, gen, indd, pgen, rel )
@@ -78,7 +124,7 @@ end );
 InstallGlobalFunction( AddToIgsParallel,
 function( pcs, gens, ppcs, pgens )
     local coll, rels, n, todo, tododo, ind, indd, g, gg, d, h, hh, k,
-          e, c, i, r, sub, val, j, f, a, b, nrmd;
+          e, c, i, r, sub, val, j, f, a, b, nrmd, pairs;
 
     if Length( gens ) = 0 then return [pcs, ppcs]; fi;
 
@@ -118,44 +164,38 @@ function( pcs, gens, ppcs, pgens )
 
             h  := ind[d];
             hh := indd[d];
-            r := FactorOrder(g);
-            a := LeadingExponent(g);
 
             # shift in
             if IsBool( h ) then
                 nrmd := NormedPcpElementPara( g, gg );
                 ind[d]  := nrmd[1];
                 indd[d] := nrmd[2];
-                Add(f,d);
+                AddSet(f,d);
                 h  := ind[d];
                 hh := indd[d];
-            elif not IsPrime(r) then
-                b := LeadingExponent(h);
-                e := Gcdex(a, b);
-                if e.coeff1 <> 0 then 
-                    nrmd := NormedPcpElementPara( (g^e.coeff1)*(h^e.coeff2), (gg^e.coeff1)*(hh^e.coeff2) );
-                    ind[d]  := nrmd[1];
-                    indd[d] := nrmd[2];
-                    Add(f,d);
-                fi;
             fi;
-
-            # divide off
             if g = h then 
                 g  := g^0;
                 gg := gg^0;
             else
-                b  := LeadingExponent(h);
-                e  := Gcdex(a,b);
-                g  := g^e.coeff3 * h^e.coeff4;
-                gg := gg^e.coeff3 * hh^e.coeff4;
+                pairs := GcdPcpPara(g, h, gg, hh);
+                h := pairs[1];
+                g := pairs[2];
+                hh := pairs[3];
+                gg := pairs[4];
+                if h <> ind[d] then
+                    nrmd := NormedPcpElementPara( h, hh );
+                    ind[d]  := nrmd[1];
+                    indd[d] := nrmd[2];
+                    AddSet(f, d);
+                fi;
             fi;
             d := Depth(g);
         od;
 
         # adjust
         c := TailLimit(ind, c);
-        ReduceExpoPara(ind,  todo, indd, tododo,  rels);
+        ReduceExpoPara(ind, todo, indd, tododo, rels);
 
         # add powers and commutators
         for d in f do

--- a/gap/basic/pcppara.gi
+++ b/gap/basic/pcppara.gi
@@ -8,19 +8,6 @@
 
 #############################################################################
 ##
-#F UpdateCounterPara( ind, c )  . . . . . . . . . . . . small help function
-##
-BindGlobal( "UpdateCounterPara", function( ind, c )
-    local i;
-    i := c - 1;
-    while i > 0 and not IsBool(ind[i]) and LeadingExponent(ind[i]) = 1 do
-        i := i - 1;
-    od;
-    return i + 1;
-end );
-
-#############################################################################
-##
 #F NormedPcpElementPara( g, gg )
 ##
 ## Parallel version of NormedPcpElement.
@@ -153,7 +140,7 @@ function( pcs, gens, ppcs, pgens )
 
     # loop over to-do list until it is empty
     while Length( todo ) > 0 and c > 1 do
-        j := Position(val, Minimum(val));
+        j := PositionMinimum(val);
         g  := Remove(todo, j);
         gg := Remove(tododo, j);
         d  := Depth( g );
@@ -201,7 +188,7 @@ function( pcs, gens, ppcs, pgens )
         for d in f do
             g :=  ind[d];
             gg := indd[d];
-            if rels[d] > 0 then
+            if d < c-1 and rels[d] > 0 then
                 r := RelativeOrderPcp(g);
                 k := g ^ r;
                 if Depth(k) < c then
@@ -210,6 +197,9 @@ function( pcs, gens, ppcs, pgens )
                 fi;
             fi;
             for j in [1..n] do
+                if j = d or Minimum( d, j ) >= c-1 then
+                    continue;
+                fi;
                 if not IsBool(ind[j]) then
                     k := Comm(g, ind[j]);
                     if Depth(k) < c then

--- a/gap/basic/pcppcps.gi
+++ b/gap/basic/pcppcps.gi
@@ -12,37 +12,6 @@
 
 #############################################################################
 ##
-#F UpdateCounter( ind, gens, c )  . . . . . . . . . . . . small help function
-##
-BindGlobal( "UpdateCounter", function( ind, gens, c )
-    local i, g;
-
-    # first reset c by ind
-    i := c - 1;
-    while i > 0 and not IsBool(ind[i]) and LeadingExponent(ind[i]) = 1 do
-        i := i - 1;
-    od;
-
-    if IsSortedList(gens) and not IsEmpty(gens) and 
-       Depth(gens[Length(gens)]) < i then
-        return i + 1;
-    fi;
-
-    # now try to add elements from gens
-    repeat
-        g := First( gens, x -> Depth(x) = i and LeadingExponent(x) = 1 );
-        if not IsBool( g ) then
-            ind[i] := g;
-            i := i - 1;
-        fi;
-    until IsBool( g );
-
-    # return value for counter
-    return i + 1;
-end );
-
-#############################################################################
-##
 #F TailLimit
 ##
 BindGlobal( "TailLimit", function( ind, c )
@@ -182,7 +151,7 @@ InstallGlobalFunction(AddToIgs, function(igs, gens)
 
     # loop over to-do list until it is empty
     while Length(todo) > 0 and c > 1 do
-        j := Position(val, Minimum(val));
+        j := PositionMinimum(val);
         g := Remove(todo, j);
         d := Depth(g);
         f := [];
@@ -218,11 +187,14 @@ InstallGlobalFunction(AddToIgs, function(igs, gens)
         # add powers and commutators
         for d in f do
             g := ind[d];
-            if rels[d] > 0 then
+            if d < c-1 and rels[d] > 0 then
                 k := g ^ RelativeOrderPcp(g);
                 if Depth(k) < c then Add(todo, k); fi;
             fi;
             for j in [1..n] do
+                if j = d or Minimum( d, j ) >= c-1 then
+                    continue;
+                fi;
                 if not IsBool(ind[j]) then
                     k := Comm(g, ind[j]);
                     if Depth(k) < c then Add(todo, k); fi;
@@ -344,7 +316,7 @@ BindGlobal( "AddIgsToIgs", function( pcs1, pcs2 )
     
     # loop over to-do list until it is empty
     while Length( todo ) > 0 and c > 1 do
-        j := Position(val, Minimum(val));
+        j := PositionMinimum(val);
         g := Remove(todo, j);
         d := Depth( g );
 

--- a/gap/basic/pcppcps.gi
+++ b/gap/basic/pcppcps.gi
@@ -121,10 +121,47 @@ IGSValFun := IGSValFun4;
 
 #############################################################################
 ##
+#F GcdPcp
+##
+BindGlobal( "GcdPcp", function(g, h)
+    local x, y, a, b, q, r, t;
+
+    x := g;
+    y := h;
+
+    a := LeadingExponent(x);
+    b := LeadingExponent(y);
+    
+    if a < 0 then
+        x := x^-1;
+        a := LeadingExponent(x);
+    fi;
+    if b < 0 then
+        y := y^-1;
+        b := LeadingExponent(y);
+    fi;
+
+    while b <> 0 do
+        q := QuoInt(a, b);
+        r := a - q * b;
+
+        t := x * y ^ -q;
+        x := y;
+        y := t;
+
+        a := b;
+        b := r;
+    od;
+
+    return [x, y];
+end );
+
+#############################################################################
+##
 #F AddToIgs( <igs>, <gens> )
 ##
 InstallGlobalFunction(AddToIgs, function(igs, gens)
-    local coll, rels, n, c, ind, g, d, todo, val, j, f, h, e, a, k, b, u, t, r;
+    local coll, rels, n, c, ind, g, d, todo, val, j, f, h, k, pair, t;
 
     if Length(gens) = 0 then return igs; fi;
 
@@ -154,30 +191,22 @@ InstallGlobalFunction(AddToIgs, function(igs, gens)
         while d < c do
 
             h := ind[d];
-            r := FactorOrder(g);
-            a := LeadingExponent(g);
-            
-            # shift in
-            if IsBool(h) then 
+            if IsBool(h) then
                 ind[d] := NormedPcpElement(g);
-                Add(f,d);
+                AddSet(f, d);
                 h := ind[d];
-            elif not IsPrime(r) then
-                b := LeadingExponent(h);
-                e := Gcdex(a, b);
-                if e.coeff1 <> 0 then 
-                    ind[d] := NormedPcpElement((g^e.coeff1)*(h^e.coeff2));
-                    Add(f,d);
-                fi;
             fi;
 
-            # divide off
-            if g = h then 
+            if g = h then
                 g := g^0;
             else
-                b := LeadingExponent(h);
-                e := Gcdex(a,b);
-                g := g^e.coeff3 * h^e.coeff4;
+                pair := GcdPcp(g, h);
+                h := pair[1];
+                g := pair[2];
+                if h <> ind[d] then
+                    ind[d] := NormedPcpElement( h );
+                    AddSet(f, d);
+                fi;
             fi;
             d := Depth(g);
         od;
@@ -281,7 +310,7 @@ end );
 ## denominator of this pcp.
 ##
 BindGlobal( "AddIgsToIgs", function( pcs1, pcs2 )
-    local coll, rels, n, ind, todo, g, c, h, eg, eh, e, d;
+    local coll, rels, n, ind, todo, g, c, h, eg, eh, e, d, pair, t, val, j;
 
     if Length( pcs1 ) = 0 then
         return AsList( pcs2 );
@@ -309,38 +338,42 @@ BindGlobal( "AddIgsToIgs", function( pcs1, pcs2 )
     od;
 
     # set counter
-    c := UpdateCounter( ind, todo, n+1 );
-
-    # create a to-do list and a pointer
+    c := TailLimit(ind, n+1);
     todo := Filtered( todo, x -> Depth( x ) < c );
-
+    val := List(todo, x -> IGSValFun(x));
+    
     # loop over to-do list until it is empty
     while Length( todo ) > 0 and c > 1 do
-        g := Remove(todo);
+        j := Position(val, Minimum(val));
+        g := Remove(todo, j);
         d := Depth( g );
 
         # shift g into ind
         while d < c do
             h := ind[d];
             if not IsBool( h ) then
-
-                # reduce g with h
-                eg := LeadingExponent( g );
-                eh := LeadingExponent( h );
-                e  := Gcdex( eg, eh );
-
                 # adjust g and ind[d] by gcd
-                ind[d] := (g^e.coeff1) * (h^e.coeff2);
-                g      := (g^e.coeff3) * (h^e.coeff4);
+                pair := GcdPcp( ind[d], g );
+                ind[d] := pair[1];
+                g      := pair[2];
             else
                 ind[d] := g;
                 g      := g^0;
             fi;
-            c := UpdateCounter( ind, todo, c );
             d := Depth( g );
         od;
+        c := TailLimit(ind, c);
+        ReduceExpo(ind, todo, rels);
+        todo := Filtered(todo, x -> Depth(x)<c);
+        val := List(todo, x -> IGSValFun(x));
     od;
-    return Filtered( ind, x -> not IsBool( x ) );
+    ind := Filtered( ind, x -> not IsBool( x ) );
+    if CHECK_IGS@ then
+        Info(InfoPcpGrp, 1, "checking igs ");
+        t := CheckIgs(ind, Concatenation(AsList(pcs1),AsList(pcs2)));
+        if t <> true then Error("igs is incorrect at ",t); fi;
+    fi;
+    return ind;
 end );
 
 #############################################################################

--- a/gap/cohom/grpcom.gi
+++ b/gap/cohom/grpcom.gi
@@ -213,9 +213,9 @@ InstallGlobalFunction( ComplementClassesCR, function( C )
                 c := CocycleConjugateComplement( C, cc, e.repr, w, g );
                 c := cc.CocToCBElement(cc, c) * cc.trf;
                 g := g * MappedVector( IntVector( c ), C.normal );
-                gens := AddIgsToIgs( [g], gens );
+                gens := AddToIgs( gens, [g] );
             elif g <> g^0 then
-                gens := AddIgsToIgs( [g], gens );
+                gens := AddToIgs( gens, [g] );
             fi;
         od;
 

--- a/gap/pcpgrp/inters.gi
+++ b/gap/pcpgrp/inters.gi
@@ -3,6 +3,35 @@
 #W  grpint.gi                  Polycyc                           Bettina Eick
 ##
 
+# Variant of ReduceExpoPara, but with IsOne's instead of IsBool's
+BindGlobal( "ReduceExpoParaInt", function( ind, indd, gen, rel )
+    local i, j, a, b, q, f, k;
+
+    for i in [1..Length(ind)] do
+        if not IsOne(ind[i]) and rel[i]=0 then
+            b := LeadingExponent(ind[i]);
+            for j in [1..i-1] do
+                if not IsOne( ind[j] ) then
+                    a := Exponents(ind[j])[i];
+                    q := QuoInt(a,b);
+                    if q <> 0 then
+                        ind[j] := ind[j]*ind[i]^-q;
+                        indd[j] := indd[j]*indd[i]^-q;
+                    fi;
+                fi;
+            od;
+            for j in [1..Length(gen)] do
+                a := Exponents(gen[j][1])[i];
+                q := QuoInt(a,b);
+                if q <> 0 then
+                    gen[j][1] := gen[j][1]*ind[i]^-q;
+                    gen[j][2] := gen[j][2]*indd[i]^-q;
+                fi;
+            od;
+        fi;
+    od;
+end );
+
 #############################################################################
 ##
 #F NormalIntersection( N, U ) . . . . . . . . . . . . . . . . . . .  U \cap N
@@ -18,12 +47,15 @@
 InstallMethod( NormalIntersection, "for pcp groups",
                IsIdenticalObj, [IsPcpGroup, IsPcpGroup],
 function( N, U )
-    local G, igs, igsN, igsU, n, s, I, id, ls, rs, is, g, d, al, ar, e, tm;
+    local G, coll, rels, igs, igsN, igsU, n, s, todo, I, id, ls, rs, is, g, d,
+          al, ar, e, tm, pairs;
 
 	# get common overgroup of N and U
-	G := PcpGroupByCollector( Collector( N ) );
+    coll := Collector( N );
+    rels := RelativeOrders( coll );
+	G    := PcpGroupByCollector( coll );
 
-    igs  := Igs(G);
+    igs  := Igs( G );
     igsN := Cgs( N );
     igsU := Cgs( U );
     n    := Length( igs );
@@ -36,7 +68,7 @@ function( N, U )
     fi;
 
     # if N or U are equal to G
-    if Length( igsN ) = n and ForAll(igsN, x -> LeadingExponent(x) = 1) then
+    if Length(igsN) = n and ForAll(igsN, x -> LeadingExponent(x) = 1) then
         return U;
     elif Length(igsU) = n and ForAll(igsU, x -> LeadingExponent(x) = 1) then
         return N;
@@ -62,31 +94,31 @@ function( N, U )
         rs[d] := g;
     od;
 
-    I := [];
+    todo := [];
     for g in igsN do
         d := Depth( g );
         if ls[d] = id then
             ls[d] := g;
         else
-            Add( I, [ g, id ] );
+            Add( todo, [ g, id ] );
         fi;
     od;
 
-    # enter the pairs [ ar, al ] of <I> into [ <ls>, <rs> ]
-    for tm in I do
+    # enter the pairs [ ar, al ] of <todo> into [ <ls>, <rs> ]
+    while not IsEmpty( todo ) do
+        tm := Remove( todo, 1 );
         al := tm[1];
         ar := tm[2];
         d  := Depth( al );
 
         # compute sum and intersection
         while al <> id and ls[d] <> id do
-            e := Gcdex( LeadingExponent(ls[d]), LeadingExponent(al) );
-            tm := ls[d]^e.coeff1 * al^e.coeff2;
-            al := ls[d]^e.coeff3 * al^e.coeff4;
-            ls[d] := tm;
-            tm := rs[d]^e.coeff1 * ar^e.coeff2;
-            ar := rs[d]^e.coeff3 * ar^e.coeff4;
-            rs[d] := tm;
+            pairs := GcdPcpPara( ls[d], al, rs[d], ar );
+            ls[d] := pairs[1];
+            al := pairs[2];
+            rs[d] := pairs[3];
+            ar := pairs[4];
+            ReduceExpoParaInt( ls, rs, todo, rels );
             d := Depth( al );
         od;
 
@@ -100,7 +132,7 @@ function( N, U )
             if tm > 0 then
                 al := al^tm;
                 ar := ar^tm;
-                Add( I, [ al, ar ] );
+                Add( todo, [ al, ar ] );
             fi;
 
         # we have a new intersection generator
@@ -110,9 +142,9 @@ function( N, U )
             # filter it into the polycyclic sequence `is`
             d := Depth( ar );
             while ar <> id and is[d] <> id  do
-                e  := Gcdex(LeadingExponent( is[d] ), LeadingExponent( ar ));
-                tm := is[d]^e.coeff1 * ar^e.coeff2;
-                ar := is[d]^e.coeff3 * ar^e.coeff4;
+                pairs := GcdPcp( is[d], ar );
+                tm := pairs[1];
+                ar := pairs[2];
                 is[d] := tm;
                 d  := Depth( ar );
             od;
@@ -124,6 +156,8 @@ function( N, U )
 
     # sum := Filtered( ls, x -> x <> id );
     I := Filtered( is, x -> x <> id );
+	# Not sure if necessary, but why not (?)
+    ReduceExpo( I, [], rels );
     return Subgroup( G, I );
 end );
 

--- a/gap/pcpgrp/normcon.gi
+++ b/gap/pcpgrp/normcon.gi
@@ -36,9 +36,16 @@ end );
 ##  bad hack ... igs and fac have to fit together.
 ##
 BindGlobal( "VectorByComplement", function( CR, U )
-    local fac, vec, igs;
+    local fac, igs, nrm, nat, res, vec;
     fac := CR.factor;
-    igs := Cgs(U);
+    if USE_CANONICAL_PCS@ then
+        igs := Cgs(U);
+    else
+        nrm := SubgroupByIgs( CR.group, NumeratorOfPcp( CR.normal ) );
+        nat := NaturalHomomorphismByNormalSubgroupNC( CR.group, nrm );
+        res := RestrictedMapping( nat, U );
+        igs := List( fac, g -> PreImagesRepresentativeNC( res, g ^ nat ) );
+    fi;
     vec := List( [1..Length(fac)], i ->
            ExponentsByPcp( CR.normal, fac[i]^-1 * igs[i] ) );
     return Flat(vec);
@@ -242,7 +249,7 @@ BindGlobal( "NormalizerOfComplement", function( C, H, N, I )
         # stabilize vector
         if Length( cc.factor.rels ) > 0 then
             Info( InfoPcpGrp, 2, "  H1 is of type ",cc.factor.rels);
-            e := cc.CocToFactor( cc, c );
+            e := cc.CocToFactor( cc, c - cc.sol );
             C := StabilizerOfCocycle( CR, cc, C, e );
         fi;
 

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -205,7 +205,6 @@ gap> e := [ 0, 0, 0, 0, 1 ];
 gap> stab := StabilizerIntegralAction( G, mats, e );
 Pcp-group with orders [ 10, 0 ]
 gap> CheckStabilizer(G, stab, mats, e);
-#I  Stabilizer not increasing: exiting.
 true
 
 #
@@ -361,7 +360,6 @@ rec( prei := g1^-90*g2^2*g3^-44*g4^16*g5^16,
 gap> CheckOrbit(G, o.prei, mats, e, f);
 true
 gap> CheckStabilizer(G, o.stab, mats, e);
-#I  Orbit longer than limit: exiting.
 true
 
 #
@@ -701,6 +699,70 @@ gap> r := G.4 * G.6 * G.7;;
 gap> h := g ^ r;;
 gap> k := ConjugacyElementsBySeries( G, g, h, pcps );;
 gap> g^k = h;
+true
+
+#
+# Fix bugs in NormalizerPcpGroup
+# <https://github.com/gap-packages/polycyclic/issues/122>
+#
+gap> tmp := USE_CANONICAL_PCS@Polycyclic;;
+gap> USE_CANONICAL_PCS@Polycyclic := true;;
+gap> H := Group( [ (5,6,8,10)(7,9,11,12)(13,15,14,16),
+> (1,2,3,4)(5,7)(6,9)(8,11)(10,12)(15,16) ] );;
+gap> V := Group( [ (1,4,3,2)(5,12,8,9)(6,7,10,11)(13,16)(14,15),
+> (1,2,3,4)(5,9,8,12)(6,11,10,7)(13,15)(14,16) ] );;
+gap> iso := IsomorphismPcpGroup( H );;
+gap> G := Image( iso );;
+gap> U := Image( iso, V );;
+gap> N := NormalizerPcpGroup( G, U );;
+gap> Images( iso, Normalizer( H, V ) ) = N;
+true
+gap> USE_CANONICAL_PCS@Polycyclic := false;;
+gap> H := Group([ (1,2)(3,4)(5,6,8,11)(7,9,12,10),
+> (1,2,3,4)(5,7,10,6)(8,11,9,12) ] );;
+gap> V := Group( [ (1,4,3,2)(5,6,10,7)(8,12,9,11) ] );;
+gap> iso := IsomorphismPcpGroup( H );;
+gap> G := Image( iso );;
+gap> U := Image( iso, V );;
+gap> N := NormalizerPcpGroup( G, U );;
+gap> Images( iso, Normalizer( H, V ) ) = N;
+true
+gap> USE_CANONICAL_PCS@Polycyclic := tmp;;
+
+#
+# Fix a bug in ComplementClassesCR
+# <https://github.com/gap-packages/polycyclic/issues/3>
+#
+gap> G:=PcGroupToPcpGroup(PcGroupCode(37830811398924985638637008775811, 144));;
+gap> FiniteSubgroupClasses(G);;
+
+#
+# Fix a bug in AddToIgs
+# <https://github.com/gap-packages/polycyclic/issues/117>
+#
+gap> G := ExamplesOfSomePcpGroups( 1 );;
+gap> x := G.1 ^ 8;;
+gap> y := G.1 ^ 3 * G.3;;
+gap> H := Subgroup( G, [ x, y ] );;
+gap> x in H;
+true
+gap> y in H;
+true
+
+#
+# Fix a bug in NormalIntersection
+# <https://github.com/gap-packages/polycyclic/issues/76>
+#
+gap> G := ExamplesOfSomePcpGroups( 8 );;
+gap> T := Subgroup( G, [ G.1^3*G.2^6*G.3^2*G.5^44, G.2^12*G.3*G.5^61, G.3^3*G.5^30, G.4^3*G.5^30, G.5^162 ] );;
+gap> K := Subgroup( G, [ G.1^3*G.2^6*G.5^3, G.2^12, G.3*G.5^7, G.4^3*G.5^3, G.5^9 ] );;
+gap> Index( K, T );
+54
+gap> I1 := NormalIntersection( T, K );
+Pcp-group with orders [ 0, 0, 0, 0, 0 ]
+gap> I2 := NormalIntersection( K, T );
+Pcp-group with orders [ 0, 0, 0, 0, 0 ]
+gap> I1 = I2 and I2 = T;
 true
 
 #

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -766,4 +766,19 @@ gap> I1 = I2 and I2 = T;
 true
 
 #
+# Another check for AddToIgs
+# Taken from p81 of the PhD thesis "Advanced Algorithms For Induced Sequences  
+# And Residual Nilpotence In Polycyclic Groups" by M. Mayer.
+#
+gap> coll := FromTheLeftCollector( 3 );;
+gap> SetConjugate( coll, 2, 1, [ 2, 1, 3, 3 ] );
+gap> SetConjugate( coll, 3, 1, [ 3, -1 ] );
+gap> SetConjugate( coll, 3, 2, [ 3, -1 ] );
+gap> UpdatePolycyclicCollector( coll );
+gap> G := PcpGroupByCollector( coll );;
+gap> V3 := Subgroup( G, [ G.1^7 * G.2^2 * G.3^-1, G.1^11 * G.2^-2 * G.3^-10 ] );;
+gap> Cgs( V3 );
+[ g1*g2^26*g3^8, g2^36*g3^9, g3^18 ]
+
+#
 gap> STOP_TEST( "bugfix.tst" );

--- a/tst/inters.tst
+++ b/tst/inters.tst
@@ -135,4 +135,23 @@ gap> Intersection(H1,H2);
 Pcp-group with orders [ 2 ]
 
 #
+gap> G := ExamplesOfSomePcpGroups( 8 );;
+gap> T := Subgroup( G, [ G.1^3*G.2^6*G.3^2*G.5^44, G.2^12*G.3*G.5^61, G.3^3*G.5^30, G.4^3*G.5^30, G.5^162 ] );;
+gap> K := Subgroup( G, [ G.1^3*G.2^6*G.5^3, G.2^12, G.3*G.5^7, G.4^3*G.5^3, G.5^9 ] );;
+gap> IsNormal( K, T );
+true
+gap> IsNormal( T, K );
+true
+gap> IsSubgroup( K, T );
+true
+gap> Index( K, T );
+54
+gap> NI1 := NormalIntersection( T, K );
+Pcp-group with orders [ 0, 0, 0, 0, 0 ]
+gap> NI2 := NormalIntersection( K, T );
+Pcp-group with orders [ 0, 0, 0, 0, 0 ]
+gap> NI1 = NI2;
+true
+
+#
 gap> STOP_TEST( "inters.tst", 10000000);

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,3 +1,10 @@
 LoadPackage("polycyclic");
+CHECK_CENT@Polycyclic      := true;
+CHECK_IGS@Polycyclic       := true;
+CHECK_INTNORM@Polycyclic   := true;
+CHECK_INTSTAB@Polycyclic   := true;
+CHECK_NORM@Polycyclic      := true;
+CHECK_SCHUR_PCP@Polycyclic := true;
+VERIFY@Polycyclic          := true;
 TestDirectory(DirectoriesPackageLibrary("polycyclic", "tst"), rec(exitGAP := true));
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
An attempt to fix #76  and #117 by fixing the igs algorithms. It would be much better to use Max Mayer's algorithms, but in the meantime perhaps this is worth considering?

The basic idea is that, in the current igs algorithms we do things like
```
e := Gcdex( LeadingExponent( g ), LeadingExponent( h ) );
k := g ^ e.coeff1 * h ^ e.coeff2;
l := g ^ e.coeff3 * h ^ e.coeff4;
```
which causes errors, because the group generated by `k` and `l` might be *strictly* contained inside the group generated by `g` and `h`. Instead, while performing the Euclidean algorithm on the leadining exponents, we multiply `g` and `h` at the same time. Essentially we are constantly repeating operations of the form
```
k := h;
l := g * h ^ -e;
```
so at every point the subgroup generated by `k` and `l` coincides with the subgroup generated by `g` and `h`.

I do think this is somewhat slower, and I also got rid of some optimisation which I wasn't sure how to "port"... but it doesn't seem too bad?

(Note: this PR includes #124, #126, and the suggestions from #127 and #128 to make tests more reliable... Most of my recent bug reports were discovered when trying to test this algorithm.)